### PR TITLE
Fix groovy 4 script execution

### DIFF
--- a/chemistry-opencmis-workbench/chemistry-opencmis-workbench/src/main/java/org/apache/chemistry/opencmis/workbench/ConsoleHelper.java
+++ b/chemistry-opencmis-workbench/chemistry-opencmis-workbench/src/main/java/org/apache/chemistry/opencmis/workbench/ConsoleHelper.java
@@ -138,8 +138,9 @@ public class ConsoleHelper {
             jSeparator.setMaximumSize(new Dimension(20, prefMenuBarHeight));
             consoleMenuBar.add(jSeparator);
 
-            String repoIdItemLabel = "<html><b> Repository ID: " + groovySession.getRepositoryInfo().getId() + "</b></html>";
+            String repoIdItemLabel = "Repository ID: " + groovySession.getRepositoryInfo().getId();
             JMenuItem repoIdItem = new JMenuItem(repoIdItemLabel);
+            repoIdItem.setFont(repoIdItem.getFont().deriveFont(Font.BOLD, repoIdItem.getFont().getSize()));
             repoIdItem.setToolTipText("Click to copy repository ID to clipboard");
             repoIdItem.addActionListener(new ActionListener() {
                 @Override

--- a/chemistry-opencmis-workbench/chemistry-opencmis-workbench/src/main/java/org/apache/chemistry/opencmis/workbench/ConsoleHelper.java
+++ b/chemistry-opencmis-workbench/chemistry-opencmis-workbench/src/main/java/org/apache/chemistry/opencmis/workbench/ConsoleHelper.java
@@ -18,13 +18,27 @@
  */
 package org.apache.chemistry.opencmis.workbench;
 
-import java.awt.Component;
-import java.awt.Cursor;
-import java.awt.Desktop;
+import groovy.console.ui.Console;
+import groovy.lang.Binding;
+import groovy.util.GroovyScriptEngine;
+import org.apache.chemistry.opencmis.client.api.Session;
+import org.apache.chemistry.opencmis.commons.SessionParameter;
+import org.apache.chemistry.opencmis.commons.impl.IOUtils;
+import org.apache.chemistry.opencmis.workbench.ClientHelper.FileEntry;
+import org.apache.chemistry.opencmis.workbench.model.ClientModel;
+import org.apache.chemistry.opencmis.workbench.model.ClientSession;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.swing.*;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultEditorKit;
+import java.awt.*;
 import java.awt.Desktop.Action;
-import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -39,28 +53,6 @@ import java.io.Writer;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.swing.JFrame;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.text.AttributeSet;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.DefaultEditorKit;
-
-import org.apache.chemistry.opencmis.client.api.Session;
-import org.apache.chemistry.opencmis.commons.SessionParameter;
-import org.apache.chemistry.opencmis.commons.impl.IOUtils;
-import org.apache.chemistry.opencmis.workbench.ClientHelper.FileEntry;
-import org.apache.chemistry.opencmis.workbench.model.ClientModel;
-import org.apache.chemistry.opencmis.workbench.model.ClientSession;
-
-import groovy.lang.Binding;
-import groovy.console.ui.Console;
-import groovy.util.GroovyScriptEngine;
 
 public class ConsoleHelper {
 
@@ -93,20 +85,8 @@ public class ConsoleHelper {
 
             final Session groovySession = model.getClientSession().getSession();
             final String user = model.getClientSession().getSessionParameters().get(SessionParameter.USER);
-            final String title = "GroovyConsole - Repsository: " + groovySession.getRepositoryInfo().getId();
 
-            final Console console = new Console(parent.getClass().getClassLoader()) {
-                @Override
-                public void updateTitle() {
-                    JFrame frame = (JFrame) getFrame();
-
-                    if (getScriptFile() != null) {
-                        frame.setTitle(((File) getScriptFile()).getName() + (getDirty() ? " * " : "") + " - " + title);
-                    } else {
-                        frame.setTitle(title);
-                    }
-                }
-            };
+            final Console console = new Console(parent.getClass().getClassLoader());
 
             console.setVariable("session", groovySession);
             console.setVariable("binding", groovySession.getBinding());
@@ -150,6 +130,27 @@ public class ConsoleHelper {
             JMenu snippetsMenu = new JMenu("Snippets");
             snippetsMenu.setMnemonic(KeyEvent.VK_N);
             consoleMenuBar.add(snippetsMenu);
+
+            // add 'copy repository id' menu item
+
+            JSeparator jSeparator = new JSeparator(JSeparator.VERTICAL);
+            int prefMenuBarHeight = (int) console.getFrame().getRootPane().getJMenuBar().getPreferredSize().getHeight();
+            jSeparator.setMaximumSize(new Dimension(20, prefMenuBarHeight));
+            consoleMenuBar.add(jSeparator);
+
+            String repoIdItemLabel = "<html><b> Repository ID: " + groovySession.getRepositoryInfo().getId() + "</b></html>";
+            JMenuItem repoIdItem = new JMenuItem(repoIdItemLabel);
+            repoIdItem.setToolTipText("Click to copy repository ID to clipboard");
+            repoIdItem.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                    clipboard.setContents(new StringSelection(groovySession.getRepositoryInfo().getId()), null);
+                }
+            });
+            consoleMenuBar.add(repoIdItem);
+
+            // add snippet menu
 
             for (FileEntry entry : readSnippetLibrary()) {
                 String snippet = ClientHelper.readFileAndRemoveHeader(entry.getFile());


### PR DESCRIPTION
Fixes groovy script execution

Previously we extended the groovy Console class
to overwrite updateTitle() to add the repository ID to the window title.
With groovy 4 up to 4.0.14 extending the Console class leads to groovy being unable to find
the doRun method of the Console base class. This solution adds a menu item showing the
repository id instead, which additionally copies the id to the clipboard when clicked.


![2023-12-23-chemistry-workbench-repo-id-in-groovy-console](https://github.com/kgs-software/chemistry-opencmis/assets/38538932/bc0d6ebf-ba97-4a29-be04-26de70aacdae)