### PR TITLE
Tolerate repeated properties in query responses

### DIFF
--- a/chemistry-opencmis-commons/chemistry-opencmis-commons-impl/src/main/java/org/apache/chemistry/opencmis/commons/impl/JSONConverter.java
+++ b/chemistry-opencmis-commons/chemistry-opencmis-commons-impl/src/main/java/org/apache/chemistry/opencmis/commons/impl/JSONConverter.java
@@ -2133,7 +2133,7 @@ public final class JSONConverter {
 
                 convertExtension(jsonPropertyMap, property, PROPERTY_KEYS);
 
-                result.addProperty(property);
+                result.replaceProperty(property);
             }
         }
 
@@ -2300,7 +2300,7 @@ public final class JSONConverter {
                 property.setLocalName(null);
             }
 
-            result.addProperty(property);
+            result.replaceProperty(property);
         }
 
         if (extJson != null) {

--- a/chemistry-opencmis-commons/chemistry-opencmis-commons-impl/src/main/java/org/apache/chemistry/opencmis/commons/impl/WSConverter.java
+++ b/chemistry-opencmis-commons/chemistry-opencmis-commons-impl/src/main/java/org/apache/chemistry/opencmis/commons/impl/WSConverter.java
@@ -1650,7 +1650,7 @@ public final class WSConverter {
         PropertiesImpl result = new PropertiesImpl();
 
         for (CmisProperty property : properties.getPropertyBooleanOrPropertyIdOrPropertyInteger()) {
-            result.addProperty(convert(property));
+            result.replaceProperty(convert(property));
         }
 
         // handle extensions

--- a/chemistry-opencmis-commons/chemistry-opencmis-commons-impl/src/main/java/org/apache/chemistry/opencmis/commons/impl/XMLConverter.java
+++ b/chemistry-opencmis-commons/chemistry-opencmis-commons-impl/src/main/java/org/apache/chemistry/opencmis/commons/impl/XMLConverter.java
@@ -2249,42 +2249,42 @@ public final class XMLConverter {
         protected boolean read(XMLStreamReader parser, QName name, PropertiesImpl target) throws XMLStreamException {
             if (isCmisNamespace(name)) {
                 if (isTag(name, TAG_PROP_STRING)) {
-                    target.addProperty(PROPERTY_STRING_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_STRING_PARSER.walk(parser));
                     return true;
                 }
 
                 if (isTag(name, TAG_PROP_ID)) {
-                    target.addProperty(PROPERTY_ID_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_ID_PARSER.walk(parser));
                     return true;
                 }
 
                 if (isTag(name, TAG_PROP_BOOLEAN)) {
-                    target.addProperty(PROPERTY_BOOLEAN_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_BOOLEAN_PARSER.walk(parser));
                     return true;
                 }
 
                 if (isTag(name, TAG_PROP_INTEGER)) {
-                    target.addProperty(PROPERTY_INTEGER_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_INTEGER_PARSER.walk(parser));
                     return true;
                 }
 
                 if (isTag(name, TAG_PROP_DATETIME)) {
-                    target.addProperty(PROPERTY_DATETIME_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_DATETIME_PARSER.walk(parser));
                     return true;
                 }
 
                 if (isTag(name, TAG_PROP_DECIMAL)) {
-                    target.addProperty(PROPERTY_DECIMAL_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_DECIMAL_PARSER.walk(parser));
                     return true;
                 }
 
                 if (isTag(name, TAG_PROP_HTML)) {
-                    target.addProperty(PROPERTY_HTML_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_HTML_PARSER.walk(parser));
                     return true;
                 }
 
                 if (isTag(name, TAG_PROP_URI)) {
-                    target.addProperty(PROPERTY_URI_PARSER.walk(parser));
+                    target.replaceProperty(PROPERTY_URI_PARSER.walk(parser));
                     return true;
                 }
             }


### PR DESCRIPTION
Some CMIS servers (e.g. Alfresco) are known to return cmis:objectId multiple times, e.g. in response to queries containing secondary type joins. Since commit 291f1fbf971f9fcb90d4815e77cb08e30279c34d, this causes an exception when parsing the response, as addProperty is only allowed to be called on properties that aren't yet present - if a property may already exist, replaceProperty is needed instead.

Note: replaceProperty is safe to call on a property that isn't yet in the PropertiesImpl, as the removal side will simply do nothing in that case.